### PR TITLE
Fix 修复 mdbook build 报错

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 fork
 source
 hub-create.sh
+docs/


### PR DESCRIPTION
SUMMARY.md 里的 404.md 页面，汉化版本是写 404.zh.md，但是缺少这个文件，导致 mdbook build 失败。

解决方法两个，一是增加 404.zh.md，二是修改 SUMMARY.md 里的 404.zh.md 文件路径。

现在采用前者方法解决这个问题。